### PR TITLE
Vermapri/knn post dataloader

### DIFF
--- a/configs/cust_config_10cm.yaml
+++ b/configs/cust_config_10cm.yaml
@@ -1,0 +1,78 @@
+# See get_default_configs() in train_ScanNet_DDP_Warmup.py
+# and get_default_configs() in model_architecture.py for the meanings of those configs
+BATCH_NORM:     True
+BATCH_SIZE:     16
+NUM_WORKERS:    24
+USE_XYZ:        True
+USE_MLP:        False
+USE_WEIGHT:     True
+USE_PE:         True
+# USE_CUDA_KERNEL: True
+device:         'cuda'
+manual_seed:    1
+sync_bn:        True
+
+print_freq:     5
+eval_freq:      5
+save_freq:      5
+
+TIME: False
+
+MAX_POINTS_NUM: 550000
+use_ASPP:       False
+NormalizedXYZ:  False
+post_knn:       True
+K_forward:      [16, 16, 16, 16, 16]
+K_propagate:    [16, 16, 16, 16, 16]
+K_self:         [16, 16, 16, 16, 16]
+point_dim:      3
+total_epoches:  16
+
+num_level:      5
+grid_size:      [0.1, 0.2, 0.4, 0.8, 1.6]
+base_dim:       64
+feat_dim:       [64, 128, 192, 256, 384]
+mid_dim:        [16,16,16,16,16]
+mid_dim_back:   1
+
+guided_level:   0
+num_heads:      8
+resblocks:      [ 0, 2, 4, 6, 6]
+resblocks_back: [ 0, 0, 0, 0, 0]
+
+train_data_path: '/nfs/hpc/share/lif-grp/Datasets/ScanNet/V2/ScanNet_withNormal/train/*.pth'
+val_data_path:   '/nfs/hpc/share/lif-grp/Datasets/ScanNet/V2/ScanNet_withNormal/val/*.pth'
+test_data_path:  '/nfs/hpc/share/lif-grp/Datasets/ScanNet/V2/ScanNet_withNormal/test/*.pth'
+pretrain:        null
+optimizer:       'AdamW'
+adamw_decay:     0.05
+learning_rate:   0.02
+gamma:           0.5
+label_smoothing: 0.2
+scheduler:       'MultiStepWithWarmup' # 'MultiStepWithWarmup' 'CosineAnnealingWarmupRestarts'
+milestones:      [80, 140, 180, 220, 260]
+ft_learning_rate: 0.016
+decay_rate:      0.0001
+ignore_label:    -100
+drop_path_rate:  0.
+dropout_rate:    0.
+dropout_fc:      0.
+layer_norm_guidance: False
+
+scheduler_update: 'step'
+warmup:           'linear'
+warmup_epochs:    10
+warmup_ratio:     0.00001
+
+use_tensorboard: False
+model_name:      'NewPointConvFormer_10cm'
+experiment_dir:  './guided_experiment_10cm/'
+ft_experiment_dir: './ft_guided_experiment_10cm/'
+num_classes:      20
+ft_model_path:   '/mnt/task_runtime/guided_experiment_10cm/hsc/model/model_best.pth'
+
+eval_path:       './evaluation_10cm/'
+
+classes:         ['wall', 'floor', 'cabinet', 'bed', 'chair', 'sofa', 'table', 'door',
+                  'window', 'bookshelf', 'picture', 'counter', 'desk', 'curtain',
+                  'refridgerator', 'shower curtain', 'toilet', 'sink', 'bathtub', 'otherfurniture']

--- a/datasetCommon.py
+++ b/datasetCommon.py
@@ -183,7 +183,7 @@ def tensorize(
         pointclouds,
         target,
         norms,
-        post_knn=True,
+        post_knn=False,
         edges_self=None,
         edges_forward=None,
         edges_propagate=None):
@@ -211,7 +211,7 @@ def listToBatch(
         pointclouds,
         target,
         norms,
-        post_knn=True,
+        post_knn=False,
         edges_self=None,
         edges_forward=None,
         edges_propagate=None,
@@ -338,7 +338,7 @@ def prepare(
     return features_out, pointclouds_out, edges_self_out, edges_forward_out, edges_propagate_out, target_out, norms_out
 
 
-def collect_fn(data_list, post_knn=True):
+def collect_fn(data_list, post_knn=False):
     """
     collect data from the data dictionary and outputs pytorch tensors
     """

--- a/datasetCommon.py
+++ b/datasetCommon.py
@@ -372,6 +372,8 @@ def collect_fn(data_list, post_knn=True):
 
     return features, pointclouds, edges_self, edges_forward, edges_propagate, target, norms
 
+
+
 def subsample(
         coord,
         norm,

--- a/knn_post_dataloader.py
+++ b/knn_post_dataloader.py
@@ -119,7 +119,7 @@ def main():
                     target, non_blocking=True), to_device(norms, non_blocking=True)
             
             # edges_self, edges_forward, edges_propagate = compute_knn_packed(pointclouds, points_stored)
-            edges_self, edges_forward, edges_propagate = compute_knn_packed(pointclouds, points_stored)
+            edges_self, edges_forward, edges_propagate = compute_knn_packed(pointclouds, points_stored, args.K_self, args.K_forward, args.K_propagate)
             edges_self, edges_forward, edges_propagate = prepare(edges_self, edges_forward, edges_propagate)
             
         timing_knn.append(time.time()-start_time)

--- a/knn_post_dataloader.py
+++ b/knn_post_dataloader.py
@@ -1,0 +1,136 @@
+# For licensing see accompanying LICENSE file.
+# Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
+
+# Usage: python enumerate_data_loader.py --config config_file
+#        example config files can be found in ./configs/
+
+import os
+import time
+import datetime
+import argparse
+import shutil
+import numpy as np
+import yaml
+from easydict import EasyDict as edict
+
+import torch
+import torch.nn as nn
+import torch.nn.parallel
+import torch.optim
+import torch.utils.data
+import torch.distributed as dist
+from tensorboardX import SummaryWriter
+
+from util.common_util import to_device, init_seeds
+from model_architecture import PointConvFormer_Segmentation as VI_PointConv
+from model_architecture import get_default_configs
+import scannet_data_loader_color_DDP as scannet_data_loader
+# from datasetCommon import compute_knn_after_tensorize
+from sklearn.neighbors import KDTree
+from pykeops.torch import LazyTensor
+# from Serialize.serialize_knn import find_knn_zorder
+from concurrent.futures import ThreadPoolExecutor
+from knn_post_dataloader_utils import prepare, compute_knn_packed
+
+
+def get_default_training_cfgs(cfg):
+    '''
+    Get default configurations w.r.t. the training and the dataset, note that this doesn't set the model default
+    configurations that is in model_architecture.get_default_configs()
+    '''
+    if 'label_smoothing' not in cfg.keys():
+        cfg.label_smoothing = False
+    if 'accum_iter' not in cfg.keys():
+        cfg.accum_iter = 1
+    if 'rotate_aug' not in cfg.keys():
+        cfg.rotate_aug = True
+    if 'flip_aug' not in cfg.keys():
+        cfg.flip_aug = False
+    if 'scale_aug' not in cfg.keys():
+        cfg.scale_aug = True
+    if 'transform_aug' not in cfg.keys():
+        cfg.transform_aug = False
+    if 'color_aug' not in cfg.keys():
+        cfg.color_aug = True
+    if 'crop' not in cfg.keys():
+        cfg.crop = False
+    if 'shuffle_index' not in cfg.keys():
+        cfg.shuffle_index = True
+    if 'mix3D' not in cfg.keys():
+        cfg.mix3D = False
+    if 'DDP' not in cfg.keys():
+        cfg.DDP = False
+    return cfg
+
+def get_parser():
+    '''
+    Get the arguments
+    '''
+    parser = argparse.ArgumentParser('ScanNet PointConvFormer')
+    parser.add_argument(
+        '--local_rank',
+        default=-1,
+        type=int,
+        help='local_rank')
+    parser.add_argument(
+        '--config',
+        default='./configWenxuanPCFDDPL5WarmUP.yaml',
+        type=str,
+        help='config file')
+
+    args = parser.parse_args()
+    assert args.config is not None
+    cfg = edict(yaml.safe_load(open(args.config, 'r')))
+    cfg = get_default_configs(cfg, cfg.num_level, cfg.base_dim)
+    cfg = get_default_training_cfgs(cfg)
+    cfg.local_rank = args.local_rank
+    cfg.config = args.config
+    return cfg
+
+def main():
+    '''
+    Main entry point for the script
+    '''
+    args = get_parser()
+    file_dir = os.path.join(args.experiment_dir, '%s_SemSeg-' %
+                            (args.model_name) +
+                            str(datetime.datetime.now().strftime('%Y-%m-%d_%H-%M')))
+    args.file_dir = file_dir
+
+    train_data_loader, val_data_loader = scannet_data_loader.getdataLoadersDDP(args)
+
+    # model = VI_PointConv(args).to(args.local_rank)
+    if torch.cuda.is_available():
+        print("CUDA is available.")
+    else:
+        print("CUDA is not available.")
+
+    # Enumerate data from train_data_loader
+    timing_knn = []
+    itr = 10
+    for t in range(itr):
+        start_time = time.time()
+        for i, data in enumerate(train_data_loader):
+            
+            features, pointclouds, target, norms, points_stored = data
+
+            features, pointclouds, target, norms = to_device(features, non_blocking=True), to_device(
+                pointclouds, non_blocking=True), to_device(
+                    target, non_blocking=True), to_device(norms, non_blocking=True)
+            
+            # edges_self, edges_forward, edges_propagate = compute_knn_packed(pointclouds, points_stored)
+            edges_self, edges_forward, edges_propagate = compute_knn_packed(pointclouds, points_stored)
+            edges_self, edges_forward, edges_propagate = prepare(edges_self, edges_forward, edges_propagate)
+            
+        timing_knn.append(time.time()-start_time)
+        print("done",t, " ", i)
+        # Example of how you might process each batch of data
+    
+    print("Average time for keops", sum(timing_knn[1:]) / (itr-1))
+       
+        
+    
+    
+
+if __name__ == '__main__':
+    main()

--- a/knn_post_dataloader_train.py
+++ b/knn_post_dataloader_train.py
@@ -68,6 +68,9 @@ def get_default_training_cfgs(cfg):
     # Augmentation for 3D Scenes. 3DV 2021
     if 'mix3D' not in cfg.keys():
         cfg.mix3D = False
+    
+    if 'post_knn' not in cfg.keys():
+        cfg.post_knn = True
     return cfg
 
 

--- a/knn_post_dataloader_train.py
+++ b/knn_post_dataloader_train.py
@@ -1,0 +1,617 @@
+#
+# For licensing see accompanying LICENSE file.
+# Copyright (C) 2022-2023 Apple Inc. All Rights Reserved.
+#
+
+# Usage: python train_ScanNet_DDP_WarmUP.py --config config_file
+#        example config files can be found in ./configs/
+
+import os
+import time
+import datetime
+import argparse
+import shutil
+import numpy as np
+import yaml
+from easydict import EasyDict as edict
+
+import torch
+import torch.nn as nn
+import torch.nn.parallel
+import torch.optim
+import torch.utils.data
+import torch.distributed as dist
+from tensorboardX import SummaryWriter
+
+from util.common_util import AverageMeter, intersectionAndUnionGPU, to_device, init_seeds
+from util.logger import get_logger
+from util.lr import MultiStepWithWarmup, CosineAnnealingWarmupRestarts
+from model_architecture import PointConvFormer_Segmentation as VI_PointConv
+from model_architecture import get_default_configs
+import scannet_data_loader_color_DDP as scannet_data_loader
+from knn_post_dataloader_utils import prepare, compute_knn_packed
+
+def get_default_training_cfgs(cfg):
+    '''
+    Get default configurations w.r.t. the training and the dataset, note that this doesn't set the model default
+    configurations that is in model_architecture.get_default_configs()
+    '''
+    # Label smoothing regularization
+    if 'label_smoothing' not in cfg.keys():
+        cfg.label_smoothing = False
+    # Accumulation iterations, i.e. the number of iterations gradients are
+    # accumulated before a parameter update is computed
+    if 'accum_iter' not in cfg.keys():
+        cfg.accum_iter = 1
+    # Random rotations augmentation
+    if 'rotate_aug' not in cfg.keys():
+        cfg.rotate_aug = True
+    # Random flip in the xy plane
+    if 'flip_aug' not in cfg.keys():
+        cfg.flip_aug = False
+    # Random scaling of the points
+    if 'scale_aug' not in cfg.keys():
+        cfg.scale_aug = True
+    # Add random noise to the point coordinates
+    if 'transform_aug' not in cfg.keys():
+        cfg.transform_aug = False
+    # Random color drop augmentation
+    if 'color_aug' not in cfg.keys():
+        cfg.color_aug = True
+    # Crop the scene to remove outliers
+    if 'crop' not in cfg.keys():
+        cfg.crop = False
+    # Random shuffle point indices
+    if 'shuffle_index' not in cfg.keys():
+        cfg.shuffle_index = True
+    # Mix3D augmentation. Engelmann et al. Mix3D: Out-of-Context Data
+    # Augmentation for 3D Scenes. 3DV 2021
+    if 'mix3D' not in cfg.keys():
+        cfg.mix3D = False
+    return cfg
+
+
+def get_parser():
+    '''
+    Get the arguments
+    '''
+    parser = argparse.ArgumentParser('ScanNet PointConvFormer')
+    parser.add_argument(
+        '--local_rank',
+        default=-1,
+        type=int,
+        help='local_rank')
+    parser.add_argument(
+        '--config',
+        default='./configWenxuanPCFDDPL5WarmUP.yaml',
+        type=str,
+        help='config file')
+
+    args = parser.parse_args()
+    assert args.config is not None
+    cfg = edict(yaml.safe_load(open(args.config, 'r')))
+    # get_default_configs gets the configurations about the model architecture
+    cfg = get_default_configs(cfg, cfg.num_level, cfg.base_dim)
+    # get_default_training_configs gets the configurations about training and
+    # data augmentations
+    cfg = get_default_training_cfgs(cfg)
+    cfg.local_rank = args.local_rank
+    cfg.config = args.config
+    return cfg
+
+
+def main_process():
+    return not args.DDP or (args.DDP and args.rank % args.num_gpus == 0)
+
+
+def main():
+    '''
+    Main entry point for the training
+    --config specifies the config file used
+    '''
+    args = get_parser()
+
+    file_dir = os.path.join(args.experiment_dir, '%s_SemSeg-' %
+                            (args.model_name) +
+                            str(datetime.datetime.now().strftime('%Y-%m-%d_%H-%M')))
+    args.file_dir = file_dir
+
+    code_dir = os.path.join(args.file_dir, 'code_log')
+
+    if args.local_rank == 0:
+        if not os.path.exists(args.experiment_dir):
+            os.makedirs(args.experiment_dir)
+
+        if not os.path.exists(file_dir):
+            os.makedirs(file_dir)
+
+        if not os.path.exists(code_dir):
+            os.makedirs(code_dir)
+        os.system('cp %s %s' % (args.config, code_dir))
+        os.system('cp %s %s' % (os.path.basename(__file__), code_dir))
+        os.system('cp %s %s' % ('scannet_data_loader_color_DDP.py', code_dir))
+        os.system('cp %s %s' % ('model_architecture.py', code_dir))
+
+    print("ignore label: ", args.ignore_label)
+
+    if 'manual_seed' in args.keys():
+        init_seeds(args.manual_seed)
+
+    args.num_gpus = torch.cuda.device_count()
+
+    main_worker(args)
+
+
+def main_worker(config):
+    global args, best_iou
+    args, best_iou = config, 0
+
+    if 'RANK' in os.environ and 'WORLD_SIZE' in os.environ:
+        args.DDP = True
+        args.rank = int(os.environ["RANK"])
+        local_rank = args.local_rank
+        print("local_rank : ", local_rank)
+        print("rank: ", args.rank)
+        torch.cuda.set_device(local_rank)
+        dist.init_process_group(
+            backend='nccl',
+            world_size=args.num_gpus,
+            rank=local_rank)
+        dist.barrier()
+
+        init_seeds(args.manual_seed + torch.distributed.get_rank())
+    else:
+        args.DDP = False
+        init_seeds(args.manual_seed)
+        local_rank = 0
+
+    if main_process():
+        global logger, writer
+        logger = get_logger(args.file_dir)
+        logger.info(args)
+        logger.info("=> Creating model ...")
+        logger.info("Classes: {}".format(args.num_classes))
+        writer = SummaryWriter(args.file_dir)
+
+    train_data_loader, val_data_loader = scannet_data_loader.getdataLoadersDDP(
+        args)
+
+    # get model
+    model = VI_PointConv(args).to(local_rank)
+    if main_process():
+        logger.info(model)
+        logger.info("#Model parameters: {}".format(
+            sum([x.nelement() for x in model.parameters()])))
+
+    # make model to DDP
+    if args.DDP:
+        if args.sync_bn:
+            model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model).cuda()
+        model = torch.nn.parallel.DistributedDataParallel(
+            model, device_ids=[local_rank])
+
+    # get loss func
+    if args.USE_WEIGHT:
+        if main_process():
+            logger.info("use weight!")
+        # Using pyTorch label smoothing
+        if args.label_smoothing:
+            criterion = nn.CrossEntropyLoss(
+                weight=torch.tensor(
+                    args.weights).float(),
+                ignore_index=args.ignore_label,
+                label_smoothing=args.label_smoothing).cuda()
+        else:
+            criterion = nn.CrossEntropyLoss(
+                weight=torch.tensor(
+                    args.weights).float(),
+                ignore_index=args.ignore_label).cuda()
+    else:
+        if args.label_smoothing:
+            criterion = nn.CrossEntropyLoss(
+                ignore_index=args.ignore_label,
+                label_smoothing=args.label_smoothing).cuda()
+        else:
+            criterion = nn.CrossEntropyLoss(
+                ignore_index=args.ignore_label).cuda()
+
+    val_criterion = nn.CrossEntropyLoss(ignore_index=args.ignore_label).cuda()
+
+    # set optimizer
+    if args.optimizer == 'SGD':
+        optimizer = torch.optim.SGD(
+            model.parameters(),
+            lr=args.learning_rate,
+            momentum=0.9)
+    elif args.optimizer == 'Adam':
+        optimizer = torch.optim.Adam(
+            model.parameters(),
+            lr=args.learning_rate,
+            betas=(0.9, 0.999),
+            eps=1e-08,
+            weight_decay=args.decay_rate)
+    elif args.optimizer == 'AdamW':
+        optimizer = torch.optim.AdamW(
+            model.parameters(),
+            lr=args.learning_rate,
+            weight_decay=args.adamw_decay)
+
+    # optimizer.param_groups[0]['initial_lr'] = cfg.learning_rate
+    init_epoch = 0
+
+    # config lr scheduler
+
+    iter_per_epoch = len(train_data_loader)
+
+    if args.scheduler == "MultiStepWithWarmup":
+        if args.milestones is not None:
+            milestones = [v * iter_per_epoch for v in args.milestones]
+        else:
+            milestones = [int(args.total_epoches * 0.4) * iter_per_epoch,
+                          int(args.total_epoches * 0.6) * iter_per_epoch,
+                          int(args.total_epoches * 0.8) * iter_per_epoch]
+        if main_process():
+            logger.info("scheduler: MultiStepWarmup!!!")
+            logger.info("milestones: {}".format(milestones))
+        scheduler = MultiStepWithWarmup(
+            optimizer,
+            milestones=milestones,
+            gamma=args.gamma,
+            warmup=args.warmup,
+            warmup_iters=args.warmup_epochs *
+            iter_per_epoch,
+            warmup_ratio=args.warmup_ratio)
+    elif args.scheduler == "CosineAnnealingWarmupRestarts":
+        if main_process():
+            logger.info("scheduler: CosineAnnealingWarmupRestarts!!!")
+        scheduler = CosineAnnealingWarmupRestarts(
+            optimizer,
+            first_cycle_steps=args.total_epoches *
+            iter_per_epoch,
+            cycle_mult=1.0,
+            max_lr=args.learning_rate,
+            min_lr=1e-8,
+            warmup_steps=args.warmup_epochs *
+            iter_per_epoch,
+            gamma=1.0)
+    else:
+        raise ValueError("No such scheduler {}".format(args.scheduler))
+
+    ############################
+    # start training  #
+    ############################
+    for epoch in range(init_epoch, args.total_epoches):
+        if args.DDP:
+            train_data_loader.sampler.set_epoch(epoch)
+
+        if main_process():
+            logger.info("lr: {}".format(scheduler.get_last_lr()))
+        loss_train, mIoU_train, mAcc_train, allAcc_train = train(
+            train_data_loader, model, criterion, optimizer, epoch, scheduler)
+
+        epoch_log = epoch + 1
+        if args.scheduler_update == 'epoch':
+            scheduler.step()
+
+        if main_process():
+            lr = scheduler.get_last_lr()
+            if isinstance(lr, list):
+                lr = lr[0]
+            if args.use_tensorboard:
+                writer.add_scalar('loss_train', loss_train, epoch_log)
+                writer.add_scalar('mIoU_train', mIoU_train, epoch_log)
+                writer.add_scalar('mAcc_train', mAcc_train, epoch_log)
+                writer.add_scalar('allAcc_train', allAcc_train, epoch_log)
+                writer.add_scalar('lr_train', lr, epoch_log)
+            #           else:
+            #               metrics_dict = {'loss_train': loss_train,
+            #                               'mIoU_train': mIoU_train,
+            #                               'mAcc_train': mAcc_train,
+            #                               'allAcc_train': allAcc_train,
+            #                               'lr_train': lr}
+
+        is_best = False
+        if epoch_log % args.eval_freq == 0:
+            loss_val, mIoU_val, mAcc_val, allAcc_val = validate(
+                val_data_loader, model, val_criterion)
+
+            if main_process():
+                if args.use_tensorboard:
+                    writer.add_scalar('loss_val', loss_val, epoch_log)
+                    writer.add_scalar('mIoU_val', mIoU_val, epoch_log)
+                    writer.add_scalar('mAcc_val', mAcc_val, epoch_log)
+                    writer.add_scalar('allAcc_val', allAcc_val, epoch_log)
+#                else:
+#                    metrics_dict = {'loss_val': loss_val,
+#                                    'mIoU_val': mIoU_val,
+#                                    'mAcc_val': mAcc_val,
+#                                    'allAcc_val': allAcc_val}
+                is_best = mIoU_val > best_iou
+                best_iou = max(best_iou, mIoU_val)
+
+        if (epoch_log % args.save_freq == 0) and main_process():
+            if not os.path.exists(args.file_dir + "/model/"):
+                os.makedirs(args.file_dir + "/model/")
+            filename = args.file_dir + '/model/model_last.pth'
+            logger.info('Saving checkpoint to : ' + filename)
+            logger.info('best IoU sofar: %.3f' % (best_iou))
+            torch.save({'epoch': epoch_log,
+                        'state_dict': model.state_dict(),
+                        'optimizer': optimizer.state_dict(),
+                        'scheduler': scheduler.state_dict(),
+                        'best_iou': best_iou,
+                        'is_best': is_best},
+                       filename)
+            if is_best:
+                shutil.copyfile(
+                    filename,
+                    args.file_dir +
+                    '/model/model_best.pth')
+
+    if main_process():
+        writer.close()
+        logger.info('===>Training done!\nBest IoU: %.3f' % (best_iou))
+
+
+def train(train_loader, model, criterion, optimizer, epoch, scheduler):
+
+    batch_time = AverageMeter()
+    data_time = AverageMeter()
+    loss_meter = AverageMeter()
+    intersection_meter = AverageMeter()
+    union_meter = AverageMeter()
+    target_meter = AverageMeter()
+    model.train()
+    end = time.time()
+    max_iter = args.total_epoches * len(train_loader)
+    if 'accum_iter' in args:
+        accum_iter = args.accum_iter
+    else:
+        accum_iter = 1
+
+    for i, data in enumerate(train_loader):
+
+        features, pointclouds, target, norms, points_stored = data
+#        print('maximum points: ', max([feat.shape[0] for feat in features]))
+        features, pointclouds, target, norms = to_device(features, non_blocking=True), to_device(
+                pointclouds, non_blocking=True), to_device(
+                    target, non_blocking=True), to_device(norms, non_blocking=True)
+        
+        edges_self, edges_forward, edges_propagate = compute_knn_packed(pointclouds, points_stored)
+        edges_self, edges_forward, edges_propagate = prepare(edges_self, edges_forward, edges_propagate)
+        # features, pointclouds, edges_self, edges_forward, edges_propagate, target, norms = to_device(
+        #     features, non_blocking=True), to_device(
+        #     pointclouds, non_blocking=True), to_device(
+        #     edges_self, non_blocking=True), to_device(
+        #         edges_forward, non_blocking=True), to_device(
+        #             edges_propagate, non_blocking=True), to_device(
+        #                 target, non_blocking=True), to_device(
+        #                     norms, non_blocking=True)
+
+        data_time.update(time.time() - end)
+        pred = model(
+            features,
+            pointclouds,
+            edges_self,
+            edges_forward,
+            edges_propagate,
+            norms)
+        pred = pred.contiguous().view(-1, args.num_classes)
+        target = target.view(-1, 1)[:, 0]
+        loss = criterion(pred, target)
+        loss /= accum_iter
+
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 10)
+        if ((i + 1) % accum_iter == 0) or ((i + 1) == len(train_loader)):
+            optimizer.step()
+            optimizer.zero_grad(set_to_none=True)
+
+        if args.scheduler_update == 'step':
+            scheduler.step()
+
+        output = pred.max(1)[1]
+        n = pred.size(0)
+        loss *= n
+        count = target.new_tensor([n], dtype=torch.long)
+        if args.DDP:
+            dist.all_reduce(loss)
+            dist.all_reduce(count)
+        n = count.item()
+        loss /= n
+
+        intersection, union, target = intersectionAndUnionGPU(
+            output, target, args.num_classes, args.ignore_label)
+        if args.DDP:
+            dist.all_reduce(intersection)
+            dist.all_reduce(union)
+            dist.all_reduce(target)
+        intersection, union, target = intersection.cpu(
+        ).numpy(), union.cpu().numpy(), target.cpu().numpy()
+        intersection_meter.update(intersection)
+        union_meter.update(union)
+        target_meter.update(target)
+
+        accuracy = sum(intersection_meter.val) / \
+            (sum(target_meter.val) + 1e-10)
+        loss_meter.update(loss.item(), n)
+        batch_time.update(time.time() - end)
+        end = time.time()
+
+        # calculate remain time
+        current_iter = epoch * len(train_loader) + i + 1
+        remain_iter = max_iter - current_iter
+        remain_time = remain_iter * batch_time.avg
+        t_m, t_s = divmod(remain_time, 60)
+        t_h, t_m = divmod(t_m, 60)
+        remain_time = '{:02d}:{:02d}:{:02d}'.format(
+            int(t_h), int(t_m), int(t_s))
+        lr = scheduler.get_last_lr()
+        if isinstance(lr, list):
+            lr = [round(x, 8) for x in lr]
+        elif isinstance(lr, float):
+            lr = round(lr, 8)
+        if (i + 1) % args.print_freq == 0 and main_process():
+            memory = torch.cuda.max_memory_reserved() / 1024 / 1024 / 1024
+            logger.info(
+                'Epoch: [{}/{}][{}/{}] '
+                'Data {data_time.val:.3f} ({data_time.avg:.3f}) '
+                'Batch {batch_time.val:.3f} ({batch_time.avg:.3f}) '
+                'Remain {remain_time} '
+                'Loss {loss_meter.val:.4f} '
+                'Lr: {lr} '
+                'Memory: {memory:.2f} GB '
+                'Accuracy {accuracy:.4f}.'.format(
+                    epoch + 1,
+                    args.total_epoches,
+                    i + 1,
+                    len(train_loader),
+                    batch_time=batch_time,
+                    data_time=data_time,
+                    remain_time=remain_time,
+                    loss_meter=loss_meter,
+                    lr=lr,
+                    accuracy=accuracy,
+                    memory=memory))
+
+        # add scalar to writer
+        if main_process():
+            if isinstance(lr, list):
+                lr = lr[0]
+            if args.use_tensorboard:
+                writer.add_scalar(
+                    'loss_train_batch',
+                    loss_meter.val,
+                    current_iter)
+                writer.add_scalar('mIoU_train_batch', np.mean(
+                    intersection / (union + 1e-10)), current_iter)
+                writer.add_scalar('mAcc_train_batch', np.mean(
+                    intersection / (target + 1e-10)), current_iter)
+                writer.add_scalar('allAcc_train_batch', accuracy, current_iter)
+                writer.add_scalar('lr_train_batch', lr, current_iter)
+#            else:
+#                metrics_dict = {'loss_train_batch': loss_meter.val,
+#                                'mIoU_train_batch': np.mean(intersection / (union + 1e-10)),
+#                                'mAcc_train_batch': np.mean(intersection / (target + 1e-10)),
+#                                'allAcc_train_batch': accuracy,
+#                                'lr_train_batch': lr}
+    iou_class = intersection_meter.sum / (union_meter.sum + 1e-10)
+    accuracy_class = intersection_meter.sum / (target_meter.sum + 1e-10)
+    mIoU = np.mean(iou_class)
+    mAcc = np.mean(accuracy_class)
+    allAcc = sum(intersection_meter.sum) / (sum(target_meter.sum) + 1e-10)
+    if main_process():
+        logger.info(
+            'Train result at epoch [{}/{}]: mIoU/mAcc/allAcc {:.4f}/{:.4f}/{:.4f}.'.format(
+                epoch +
+                1,
+                args.total_epoches,
+                mIoU,
+                mAcc,
+                allAcc))
+    return loss_meter.avg, mIoU, mAcc, allAcc
+
+
+def validate(val_loader, model, criterion):
+    if main_process():
+        logger.info(
+            '>>>>>>>>>>>>>>>>>>> Start Evaluation >>>>>>>>>>>>>>>>>>>>>>')
+
+    batch_time = AverageMeter()
+    data_time = AverageMeter()
+    loss_meter = AverageMeter()
+    intersection_meter = AverageMeter()
+    union_meter = AverageMeter()
+    target_meter = AverageMeter()
+
+    torch.cuda.empty_cache()
+
+    model.eval()
+    end = time.time()
+    for i, data in enumerate(val_loader):
+
+        # features, pointclouds, edges_self, edges_forward, edges_propagate, target, norms = data
+        features, pointclouds, target, norms, points_stored = data
+
+        features, pointclouds, target, norms = \
+            to_device(features), to_device(pointclouds), \
+             to_device(target), to_device(norms)
+
+        edges_self, edges_forward, edges_propagate = compute_knn_packed(pointclouds, points_stored)
+        edges_self, edges_forward, edges_propagate = prepare(edges_self, edges_forward, edges_propagate)
+
+        data_time.update(time.time() - end)
+
+        with torch.no_grad():
+            pred = model(
+                features,
+                pointclouds,
+                edges_self,
+                edges_forward,
+                edges_propagate,
+                norms)
+            pred = pred.contiguous().view(-1, args.num_classes)
+            target = target.view(-1, 1)[:, 0]
+            loss = criterion(pred, target)
+
+        output = pred.max(1)[1]
+        n = output.size(0)
+        loss *= n
+        count = target.new_tensor([n], dtype=torch.long)
+        if args.DDP:
+            dist.all_reduce(loss)
+            dist.all_reduce(count)
+        n = count.item()
+        loss /= n
+
+        intersection, union, target = intersectionAndUnionGPU(
+            output, target, args.num_classes, args.ignore_label)
+        if args.DDP:
+            dist.all_reduce(intersection)
+            dist.all_reduce(union)
+            dist.all_reduce(target)
+        intersection, union, target = intersection.cpu().numpy(), union.cpu().numpy(), target.cpu().numpy()
+        intersection_meter.update(intersection)
+        union_meter.update(union)
+        target_meter.update(target)
+
+        accuracy = sum(intersection_meter.val) / \
+            (sum(target_meter.val) + 1e-10)
+        loss_meter.update(loss.item(), n)
+        batch_time.update(time.time() - end)
+        end = time.time()
+        if (i + 1) % args.print_freq == 0 and main_process():
+            logger.info(
+                'Test: [{}/{}] '
+                'Data {data_time.val:.3f} ({data_time.avg:.3f}) '
+                'Batch {batch_time.val:.3f} ({batch_time.avg:.3f}) '
+                'Loss {loss_meter.val:.4f} ({loss_meter.avg:.4f}) '
+                'Accuracy {accuracy:.4f}.'.format(
+                    i + 1,
+                    len(val_loader),
+                    data_time=data_time,
+                    batch_time=batch_time,
+                    loss_meter=loss_meter,
+                    accuracy=accuracy))
+
+    iou_class = intersection_meter.sum / (union_meter.sum + 1e-10)
+    # print('iou_class : ', iou_class)
+    accuracy_class = intersection_meter.sum / (target_meter.sum + 1e-10)
+    mIoU = np.mean(iou_class)
+    mAcc = np.mean(accuracy_class)
+    allAcc = sum(intersection_meter.sum) / (sum(target_meter.sum) + 1e-10)
+    if main_process():
+        logger.info(
+            'Val result: mIoU/mAcc/allAcc {:.4f}/{:.4f}/{:.4f}.'.format(mIoU, mAcc, allAcc))
+        for i in range(args.num_classes):
+            logger.info('Class_{} Result: iou/accuracy {:.4f}/{:.4f}.'.format(i,
+                        iou_class[i], accuracy_class[i]))
+        logger.info('<<<<<<<<<<<<<<<<< End Evaluation <<<<<<<<<<<<<<<<<')
+
+    return loss_meter.avg, mIoU, mAcc, allAcc
+
+
+if __name__ == '__main__':
+    import gc
+    gc.collect()
+    main()

--- a/knn_post_dataloader_train.py
+++ b/knn_post_dataloader_train.py
@@ -377,7 +377,7 @@ def train(train_loader, model, criterion, optimizer, epoch, scheduler):
                 pointclouds, non_blocking=True), to_device(
                     target, non_blocking=True), to_device(norms, non_blocking=True)
         
-        edges_self, edges_forward, edges_propagate = compute_knn_packed(pointclouds, points_stored)
+        edges_self, edges_forward, edges_propagate = compute_knn_packed(pointclouds, points_stored, args.K_self, args.K_forward, args.K_propagate)
         edges_self, edges_forward, edges_propagate = prepare(edges_self, edges_forward, edges_propagate)
         # features, pointclouds, edges_self, edges_forward, edges_propagate, target, norms = to_device(
         #     features, non_blocking=True), to_device(
@@ -537,7 +537,7 @@ def validate(val_loader, model, criterion):
             to_device(features), to_device(pointclouds), \
              to_device(target), to_device(norms)
 
-        edges_self, edges_forward, edges_propagate = compute_knn_packed(pointclouds, points_stored)
+        edges_self, edges_forward, edges_propagate = compute_knn_packed(pointclouds, points_stored, args.K_self, args.K_forward, args.K_propagate)
         edges_self, edges_forward, edges_propagate = prepare(edges_self, edges_forward, edges_propagate)
 
         data_time.update(time.time() - end)

--- a/knn_post_dataloader_utils.py
+++ b/knn_post_dataloader_utils.py
@@ -1,0 +1,227 @@
+import torch
+import numpy as np
+from sklearn.neighbors import KDTree
+from pykeops.torch import LazyTensor
+
+def knn_keops(ref_points, query_points, K):
+    """
+    Compute k-nearest neighbors using KeOps, and return indices as NumPy arrays.
+    """
+    # Ensure inputs are PyTorch tensors
+    if isinstance(ref_points, np.ndarray):
+        ref_points = torch.tensor(ref_points, dtype=torch.float32)
+    if isinstance(query_points, np.ndarray):
+        query_points = torch.tensor(query_points, dtype=torch.float32)
+    
+    # # Move tensors to CUDA if available
+    # ref_points = ref_points.cuda()
+    # query_points = query_points.cuda()
+    
+    # Compute pairwise squared distances using LazyTensor
+    ref_lazy = LazyTensor(ref_points[:, None, :])  # Mx1xD
+    query_lazy = LazyTensor(query_points[None, :, :])  # 1xNxD
+    distances = ((ref_lazy - query_lazy) ** 2).sum(-1)  # Pairwise squared distances (MxN)
+    
+    # Get top K minimum distances and corresponding indices
+    indices = distances.argKmin(K, dim=0)  # Shape: (N, K)
+    # indices = indices.cpu().numpy()
+    del ref_lazy, query_lazy, distances
+    # torch.cuda.empty_cache()
+    # Convert the indices to a NumPy array
+    return indices  # Move to CPU and convert to NumPy
+
+def compute_knn(ref_points, query_points, K, dilated_rate=1, method='keops'):
+    """
+    Compute KNN
+    Input:
+        ref_points: reference points (MxD)
+        query_points: query points (NxD)
+        K: the amount of neighbors for each point
+        dilated_rate: If set to larger than 1, then select more neighbors and then choose from them
+        (Engelmann et al. Dilated Point Convolutions: On the Receptive Field Size of Point Convolutions on 3D Point Clouds. ICRA 2020)
+        method: Choose between two approaches: Scikit-Learn ('sklearn') or nanoflann ('nanoflann'). In general nanoflann should be faster, but sklearn is more stable
+    Output:
+        neighbors_idx: for each query point, its K nearest neighbors among the reference points (N x K)
+    """
+    num_ref_points = ref_points.shape[0]
+
+    if num_ref_points < K or num_ref_points < dilated_rate * K:
+        num_query_points = query_points.shape[0]
+        inds = np.random.choice(
+            num_ref_points, (num_query_points, K)).astype(
+            np.int32)
+
+        return inds
+    if method == 'sklearn':
+        print("Using sklearn")
+        kdt = KDTree(ref_points)
+        neighbors_idx = kdt.query(
+            query_points,
+            k=K * dilated_rate,
+            return_distance=False)
+    elif method == 'keops':
+        # print("Using keops")
+        neighbors_idx = knn_keops(ref_points, query_points, K*dilated_rate)
+
+    # elif method == 'nanoflann':
+    #     neighbors_idx = batch_neighbors(
+    #         query_points, ref_points, [
+    #             query_points.shape[0]], [num_ref_points], K * dilated_rate)
+    else:
+        raise Exception('compute_knn: unsupported knn algorithm')
+    if dilated_rate > 1:
+        neighbors_idx = np.array(
+            neighbors_idx[:, ::dilated_rate], dtype=np.int32)
+
+    return neighbors_idx
+
+def tensorizeTensorList(tensor_list):
+    """
+    Make all tensors inside a list have an additional batch dimension.
+    """
+    ret_list = []
+    for tensor_item in tensor_list:
+        if tensor_item is None:
+            ret_list.append(None)
+        else:
+            ret_list.append(tensor_item.unsqueeze(0))
+    return ret_list
+
+
+def tensorize(edges_self, edges_forward, edges_propagate):
+    """
+    Tensorize transforms a batch of multiple edge sets into a single tensor.
+    This focuses only on `edges_self`, `edges_forward`, and `edges_propagate`.
+    """
+    edges_self = tensorizeTensorList(edges_self)
+    edges_forward = tensorizeTensorList(edges_forward)
+    edges_propagate = tensorizeTensorList(edges_propagate)
+
+    return edges_self, edges_forward, edges_propagate
+
+
+def listToBatch(edges_self, edges_forward, edges_propagate):
+    """
+    ListToBatch transforms a batch of multiple edge sets into a single set.
+    Focused on `edges_self`, `edges_forward`, and `edges_propagate`.
+    This version uses PyTorch tensors.
+    """
+    num_sample = len(edges_self)
+
+    # Initialize batches for the first sample
+    edgesSelfBatch = edges_self[0]
+    edgesForwardBatch = edges_forward[0]
+    edgesPropagateBatch = edges_propagate[0]
+    
+    # Track the cumulative number of points stored
+    points_stored = [val.shape[0] for val in edges_self[0]]
+
+    for i in range(1, num_sample):
+        for j in range(len(edges_forward[i])):
+            # Handle edges_forward
+            tempMask = edges_forward[i][j] == -1
+            edges_forwardAdd = edges_forward[i][j] + points_stored[j]
+            edges_forwardAdd[tempMask] = -1
+            edgesForwardBatch[j] = torch.cat([edgesForwardBatch[j], edges_forwardAdd], dim=0)
+
+            # Handle edges_propagate
+            tempMask2 = edges_propagate[i][j] == -1
+            edges_propagateAdd = edges_propagate[i][j] + points_stored[j + 1]
+            edges_propagateAdd[tempMask2] = -1
+            edgesPropagateBatch[j] = torch.cat([edgesPropagateBatch[j], edges_propagateAdd], dim=0)
+
+        for j in range(len(edges_self[i])):
+            # Handle edges_self
+            tempMask3 = edges_self[i][j] == -1
+            edges_selfAdd = edges_self[i][j] + points_stored[j]
+            edges_selfAdd[tempMask3] = -1
+            edgesSelfBatch[j] = torch.cat([edgesSelfBatch[j], edges_selfAdd], dim=0)
+
+            # Update points_stored
+            points_stored[j] += edges_self[i][j].shape[0]
+
+    return edgesSelfBatch, edgesForwardBatch, edgesPropagateBatch
+
+def prepare(edges_self, edges_forward, edges_propagate):
+    """
+    Prepare data coming from data loader (lists of numpy arrays) into torch tensors ready to send to training.
+    Focused on `edges_self`, `edges_forward`, and `edges_propagate`.
+    """
+    edges_self_out, edges_forward_out, edges_propagate_out = \
+        listToBatch(edges_self, edges_forward, edges_propagate)
+
+    edges_self_out, edges_forward_out, edges_propagate_out = \
+        tensorize(edges_self_out, edges_forward_out, edges_propagate_out)
+
+    return edges_self_out, edges_forward_out, edges_propagate_out
+
+
+def make_cumulative(original):
+    
+    for i in range(0, len(original)):
+        temp_list = []
+        temp_list.append(0)
+        for itr in original[i]:
+            temp_list.append(temp_list[-1] + itr)
+        original[i] = temp_list
+    # for i in range(1, len(original)):
+        
+            
+    return original
+
+def compute_knn_packed(pointclouds, points_stored, K_self=16, K_forward=16, K_propagate=16):
+    """
+    Compute kNN for the given pointclouds after tensorization and batching.
+    Input:
+        pointclouds: list of pointclouds from different grid sizes, each of shape [N_j, 3]
+        K_self: number of neighbors within each subsampling level
+        K_forward: number of neighbors from one subsampling level to the next one (downsampling)
+        K_propagate: number of neighbors from one subsampling level to the previous one (upsampling)
+    Outputs:
+        nei_forward_list: downsampling kNN neighbors (K_forward neighbors for each point)
+        nei_propagate_list: upsampling kNN neighbors (K_propagate neighbors for each point)
+        nei_self_list: kNN neighbors within the same layer
+    """
+
+    
+    n = len(points_stored[0])
+
+    nei_forward_list   = [[] for _ in range(n)]
+    nei_propagate_list = [[] for _ in range(n)]
+    nei_self_list      = [[] for _ in range(n)]
+
+    points_stored = make_cumulative(points_stored)
+   
+    for i in range(n):
+
+        temp_points = []
+        temp_points.append(pointclouds[0][:, points_stored[0][i]:points_stored[0][i+1], :])
+        temp_points.append(pointclouds[1][:, points_stored[1][i]:points_stored[1][i+1], :])
+        temp_points.append(pointclouds[2][:, points_stored[2][i]:points_stored[2][i+1], :])
+        temp_points.append(pointclouds[3][:, points_stored[3][i]:points_stored[3][i+1], :])
+        temp_points.append(pointclouds[4][:, points_stored[4][i]:points_stored[4][i+1], :])
+        
+        nei_forward_list_temp   = []
+        nei_self_list_temp      = []
+        nei_propagate_list_temp = []
+
+        for j in range(len(pointclouds)):
+            temp_points[j] = temp_points[j].squeeze(0)
+            if j == 0:
+                nself = compute_knn(temp_points[j], temp_points[j], K_self)
+                nei_self_list_temp.append(nself)
+            else:
+                nei_forward   = compute_knn(temp_points[j-1], temp_points[j], K_forward)
+                nei_propagate = compute_knn(temp_points[j], temp_points[j-1], K_propagate)
+                nself         = compute_knn(temp_points[j], temp_points[j], K_self)
+                
+                nei_forward_list_temp.append(nei_forward)
+                nei_propagate_list_temp.append(nei_propagate)
+                nei_self_list_temp.append(nself)
+        
+        nei_forward_list[i]   = nei_forward_list_temp
+        nei_propagate_list[i] = nei_propagate_list_temp
+        nei_self_list[i]      = nei_self_list_temp
+        # print(len(nei_self_list_temp))
+
+    return nei_self_list, nei_forward_list, nei_propagate_list

--- a/knn_post_dataloader_utils.py
+++ b/knn_post_dataloader_utils.py
@@ -169,7 +169,7 @@ def make_cumulative(original):
             
     return original
 
-def compute_knn_packed(pointclouds, points_stored, K_self=16, K_forward=16, K_propagate=16):
+def compute_knn_packed(pointclouds, points_stored, K_self, K_forward, K_propagate):
     """
     Compute kNN for the given pointclouds after tensorization and batching.
     Input:
@@ -208,12 +208,12 @@ def compute_knn_packed(pointclouds, points_stored, K_self=16, K_forward=16, K_pr
         for j in range(len(pointclouds)):
             temp_points[j] = temp_points[j].squeeze(0)
             if j == 0:
-                nself = compute_knn(temp_points[j], temp_points[j], K_self)
+                nself = compute_knn(temp_points[j], temp_points[j], K_self[j])
                 nei_self_list_temp.append(nself)
             else:
-                nei_forward   = compute_knn(temp_points[j-1], temp_points[j], K_forward)
-                nei_propagate = compute_knn(temp_points[j], temp_points[j-1], K_propagate)
-                nself         = compute_knn(temp_points[j], temp_points[j], K_self)
+                nei_forward   = compute_knn(temp_points[j-1], temp_points[j], K_forward[j])
+                nei_propagate = compute_knn(temp_points[j], temp_points[j-1], K_propagate[j])
+                nself         = compute_knn(temp_points[j], temp_points[j], K_self[j])
                 
                 nei_forward_list_temp.append(nei_forward)
                 nei_propagate_list_temp.append(nei_propagate)

--- a/scannet_data_loader_color_DDP.py
+++ b/scannet_data_loader_color_DDP.py
@@ -12,7 +12,7 @@ from torch.utils.data import Dataset
 import transforms as t
 from util.voxelize import voxelize
 
-from datasetCommon import subsample_and_knn, compute_weight, collect_fn
+from datasetCommon import subsample_and_knn, compute_weight, collect_fn, subsample
 
 
 class ScanNetDataset(Dataset):
@@ -165,9 +165,8 @@ class ScanNetDataset(Dataset):
         return self.data[indx][3]
 
     def __getitem__(self, indx):
-        coord, features, label, _ = self.data[indx]
+        coord, color, label, norm = self.data[indx]
 
-        color, norm = features[:, :3], features[:, 3:]
 
         # move z to 0+
         z_min = coord[:, 2].min()
@@ -218,17 +217,28 @@ class ScanNetDataset(Dataset):
             for crop_idx in uniq_idx:
                 data = {}
                 coord_part, norm_part = coord[crop_idx], norm[crop_idx]
-                point_list, nei_forward_list, nei_propagate_list, nei_self_list, norm_list \
-                    = subsample_and_knn(coord_part, norm_part, grid_size=self.cfg.grid_size, K_self=self.cfg.K_self,
-                                        K_forward=self.cfg.K_forward, K_propagate=self.cfg.K_propagate)
-                data['point_list'] = point_list
-                data['nei_forward_list'] = nei_forward_list
-                data['nei_propagate_list'] = nei_propagate_list
-                data['nei_self_list'] = nei_self_list
-                data['surface_normal_list'] = norm_list
-                data['feature_list'] = [color[crop_idx].astype(np.float32)]
-                data['label_list'] = [label[crop_idx].astype(np.int32)]
-                data['crop_idx'] = crop_idx
+
+                if self.cfg.post_knn:
+                    point_list, norm_list = subsample(coord_part, norm_part, grid_size=self.cfg.grid_size)
+    
+                    data['point_list'] = point_list
+                    data['surface_normal_list'] = norm_list
+                    data['feature_list'] = [color[crop_idx].astype(np.float32)]
+                    data['label_list'] = [label[crop_idx].astype(np.int32)]
+                    data['crop_idx'] = crop_idx
+
+                else:     
+                    point_list, nei_forward_list, nei_propagate_list, nei_self_list, norm_list \
+                        = subsample_and_knn(coord_part, norm_part, grid_size=self.cfg.grid_size, K_self=self.cfg.K_self,
+                                            K_forward=self.cfg.K_forward, K_propagate=self.cfg.K_propagate)
+                    data['point_list'] = point_list
+                    data['nei_forward_list'] = nei_forward_list
+                    data['nei_propagate_list'] = nei_propagate_list
+                    data['nei_self_list'] = nei_self_list
+                    data['surface_normal_list'] = norm_list
+                    data['feature_list'] = [color[crop_idx].astype(np.float32)]
+                    data['label_list'] = [label[crop_idx].astype(np.int32)]
+                    data['crop_idx'] = crop_idx
                 all_data.append(data)
             return all_data
 
@@ -245,19 +255,31 @@ class ScanNetDataset(Dataset):
 
 
         # print("number of points: ", coord.shape[0])
+        if self.cfg.post_knn:
+            point_list, norm_list = subsample(coord, norm, grid_size=self.cfg.grid_size)
+            all_data['point_list'] = point_list
+            all_data['surface_normal_list'] = norm_list
+            all_data['feature_list'] = [color.astype(np.float32)]
+            all_data['label_list'] = [label.astype(np.int32)]
 
-        point_list, nei_forward_list, nei_propagate_list, nei_self_list, norm_list = \
-            subsample_and_knn(coord, norm, grid_size=self.cfg.grid_size, K_self=self.cfg.K_self,
-                              K_forward=self.cfg.K_forward, K_propagate=self.cfg.K_propagate)
-        all_data['point_list'] = point_list
-        all_data['nei_forward_list'] = nei_forward_list
-        all_data['nei_propagate_list'] = nei_propagate_list
-        all_data['nei_self_list'] = nei_self_list
-        all_data['surface_normal_list'] = norm_list
-        all_data['feature_list'] = [color.astype(np.float32)]
-        all_data['label_list'] = [label.astype(np.int32)]
+        else:
+            point_list, nei_forward_list, nei_propagate_list, nei_self_list, norm_list = \
+                subsample_and_knn(coord, norm, grid_size=self.cfg.grid_size, K_self=self.cfg.K_self,
+                                K_forward=self.cfg.K_forward, K_propagate=self.cfg.K_propagate)
+            all_data['point_list'] = point_list
+            all_data['nei_forward_list'] = nei_forward_list
+            all_data['nei_propagate_list'] = nei_propagate_list
+            all_data['nei_self_list'] = nei_self_list
+            all_data['surface_normal_list'] = norm_list
+            all_data['feature_list'] = [color.astype(np.float32)]
+            all_data['label_list'] = [label.astype(np.int32)]
 
         return all_data
+
+def create_collect_fn(post_knn):
+    def wrapped_collect_fn(data_list):
+        return collect_fn(data_list, post_knn=post_knn)
+    return wrapped_collect_fn
 
 
 def getdataLoadersDDP(cfg):
@@ -305,7 +327,7 @@ def getdataLoaders(cfg, sampler):
 
     train_data_loader = torch.utils.data.DataLoader(training_dataset,
                                                     batch_size=cfg.BATCH_SIZE, 
-                                                    collate_fn=collect_fn, 
+                                                    collate_fn=create_collect_fn(cfg.post_knn), 
                                                     num_workers=cfg.NUM_WORKERS, 
                                                     pin_memory=True,
                                                     sampler=training_sampler,
@@ -313,7 +335,7 @@ def getdataLoaders(cfg, sampler):
 
     val_data_loader = torch.utils.data.DataLoader(validation_dataset,
                                                   batch_size=cfg.BATCH_SIZE, 
-                                                  collate_fn=collect_fn, 
+                                                  collate_fn=create_collect_fn(cfg.post_knn), 
                                                   num_workers=cfg.NUM_WORKERS, 
                                                   sampler=validation_sampler,
                                                   pin_memory=True)

--- a/train_ScanNet_DDP_WarmUP.py
+++ b/train_ScanNet_DDP_WarmUP.py
@@ -68,6 +68,11 @@ def get_default_training_cfgs(cfg):
     # Augmentation for 3D Scenes. 3DV 2021
     if 'mix3D' not in cfg.keys():
         cfg.mix3D = False
+    
+    if 'post_knn' not in cfg.keys():
+        cfg.post_knn = False
+
+        
     return cfg
 
 


### PR DESCRIPTION
In this branch, the key change is the introduction of `post_knn` in the config file, allowing KNN computation on the GPU after the dataloader instead of within the CPU-based dataloader. We use KeOps for KNN computation post-dataloader.

The file` knn_post_dataloader_train.py` provides an example of how to implement this, while `knn_post_dataloader_utils.py` contains the necessary functions for retrieving correct values and performing KNN computation using KeOps.

Additionally, the previous functionality remains unchanged—if post_knn is not specified in the config file, the codebase functions as in the previous version.